### PR TITLE
Card columns width adjusted for screens of different sizes, as well as styling fixes to cards.

### DIFF
--- a/public/css/stylesheet.css
+++ b/public/css/stylesheet.css
@@ -4,6 +4,7 @@ html, body{
   font-family: 'Raleway', sans-serif;
   margin:0;
   padding: 0;
+  background-color: rgb(250,250,250);
 }
 header{
 	background-color: #ffe4c4;
@@ -16,11 +17,6 @@ main{
 	min-height: 82%;
 }
 
-/* Fixes card columns clearing eachother, not sure if necessary */
-.card{
-	display: inline-block;
-}
-
 /* Nav Hover Color */
 .nav-link:hover{
    color:#5DB856 !important;
@@ -31,4 +27,38 @@ main{
 	color: #d0f2f1;
 	font-weight:bold;
 	font-size: 1.4em;
+}
+
+/* Card Column on Homepage CSS */
+/* Small Screens */
+@media (min-width: 34em) {
+    .card-columns {
+        -webkit-column-count: 2;
+        -moz-column-count: 2;
+        column-count: 2;
+    }
+}
+/* Medium Screens*/
+@media (min-width: 48em) {
+    .card-columns {
+        -webkit-column-count: 3;
+        -moz-column-count: 3;
+        column-count: 3;
+    }
+}
+/* Large Screens */
+@media (min-width: 62em) {
+    .card-columns {
+        -webkit-column-count: 4;
+        -moz-column-count: 4;
+        column-count: 4;
+    }
+}
+/* X-Large Screens*/
+@media (min-width: 75em) {
+    .card-columns {
+        -webkit-column-count: 5;
+        -moz-column-count: 5;
+        column-count: 5;
+    }
 }

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -20,7 +20,7 @@
 		<div class="card-columns">
             @foreach ($products as $product)
             <!-- Card -->
-            <div class="card">
+            <div class="card mb-3">
                 <img class="card-img-top img-fluid" width="100%" src="{{ asset($product->image) }}" alt="Card Image">
                 <div class="card-block">
                     <span class="card-title h4">{{ $product->title }}</span>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -22,12 +22,13 @@
             <!-- Card -->
             <div class="card mb-3">
                 <img class="card-img-top img-fluid" width="100%" src="{{ asset($product->image) }}" alt="Card Image">
-                <div class="card-block">
-                    <span class="card-title h4">{{ $product->title }}</span>
-                    <p class="card-text"> $ {{ $product->price }}</p>
-                    <p class="card-text">{{ $product->description }}</p>
-                    <footer>
-                        <small class="text-muted">Posted: {{ date('jS \of F Y', strtotime($product->created_at)) }}</small>
+                <div class="card-block p-3">
+                    <span class="card-title h4 text-justify">{{ $product->title }}</span>
+                    <!-- <p class="card-text text-justify"> $ {{ $product->price }}</p> -->
+                    <p class="card-text mb-1">{{ $product->description }}</p>
+                    <footer class="text-right">
+						<small class="text-muted">Posted: {{ date('F jS, Y', strtotime($product->created_at)) }}</small><br/>
+						<span class="badge badge-success">$ {{ $product->price }}</span>
                     </footer>
                 </div>
             </div>


### PR DESCRIPTION
Card columns are now:
XS: 1
SM: 2
M: 3
L: 4
XL: 5

Style applied to cards:
- Margin reduced inside card to fit in more content in less white space.  
- Title and ad description text jsutified
- Pill added for price
- Price and Date right aligned
- Added a margin to the bottom of cards to clear each-other on XS screens
- Date format changed for readability